### PR TITLE
[#1309] Respect X-Forwarded-* headers

### DIFF
--- a/os_fdp_adapters/app.py
+++ b/os_fdp_adapters/app.py
@@ -2,6 +2,7 @@ import sys
 
 from flask import Flask
 from flask.ext.cors import CORS
+from werkzeug.contrib.fixers import ProxyFix
 
 import logging
 
@@ -20,6 +21,7 @@ root.addHandler(ch)
 def create_app():
     logging.info('OS-FDP-ADAPTERS create_app')
     app = Flask('os_fdp_adapters')
+    app.wsgi_app = ProxyFix(app.wsgi_app)
     logging.info('OS-API configuring blueprints')
     app.register_blueprint(OSFdpAdapter, url_prefix='/')
     CORS(app)


### PR DESCRIPTION
Specially X-Forwarded-proto, which controls the protocol used on redirects.
We need to redirect to the same protocol used by our proxy (HTTPS), regardless
if we are ourselves running HTTP or HTTPS.

openspending/openspending#1309